### PR TITLE
Introduced a unified game report endpoint by combining data from the Steam Web API and RAWG. It also refactors existing services to focus on Steam game-only data and removes unused or redundant functionality.

### DIFF
--- a/app/api/combined.py
+++ b/app/api/combined.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Query
+from app.services.combined_service import get_full_report
+from app.utils.response import success_response, error_response
+
+router = APIRouter(prefix="/report", tags=["Report"])
+
+
+@router.get(
+    "/",
+    summary="Get full game report",
+    description="Returns a full Steam-focused game report using RAWG metadata and Steam achievement rarity data."
+)
+def game_report(game_name: str = Query(..., description="Steam game title to search for")):
+    result = get_full_report(game_name)
+
+    if result.get("status_code") != 200:
+        return error_response(
+            code="GAME_REPORT_ERROR",
+            message=result.get("error", "Unknown game report error"),
+            status_code=result["status_code"],
+        )
+
+    return success_response(
+        data={
+            "game": result.get("game")
+        }
+    )

--- a/app/api/rawg.py
+++ b/app/api/rawg.py
@@ -1,24 +1,27 @@
-from fastapi import APIRouter
-from app.services.rawg_service import search_games
+from fastapi import APIRouter, Query
+from app.services.rawg_service import search_for_steam_game_by_name
 from app.utils.response import success_response, error_response
 
 router = APIRouter(prefix="/rawg", tags=["RAWG"])
 
 
-@router.get("/search")
-def rawg_search(query: str):
-    result = search_games(query)
+@router.get(
+    "/search",
+    summary="Search for a Steam game using RAWG",
+    description="Finds the first RAWG result that matches the query and is available on Steam."
+)
+def rawg_search(query: str = Query(..., description="Game title to search for")):
+    result = search_for_steam_game_by_name(query)
 
     if result["status_code"] != 200:
         return error_response(
-            code = "RAWG_API_ERROR",
-            message = result.get("error", "Unknown RAWG Error"),
-            status_code = result["status_code"]
+            code="RAWG_API_ERROR",
+            message=result.get("error", "Unknown RAWG error"),
+            status_code=result["status_code"]
         )
-    else:
-        return success_response(
-            data = {
-                "count": result["count"],
-                "results": result["results"]
-                }
-        )
+
+    return success_response(
+        data={
+            "game": result.get("game")
+        }
+    )

--- a/app/api/steam.py
+++ b/app/api/steam.py
@@ -1,46 +1,29 @@
-from fastapi import APIRouter
-from app.services.steam_service import (
-    get_player_summary,
-    get_achievements_with_rarity_by_name
-)
+from fastapi import APIRouter, Query
+from app.services.steam_service import get_achievements_with_rarity
 from app.utils.response import success_response, error_response
 
 router = APIRouter(prefix="/steam", tags=["Steam"])
 
 
-@router.get("/player/{steam_id}")
-def steam_player_summary(steam_id: str):
-    result = get_player_summary(steam_id)
+@router.get(
+    "/achievements",
+    summary="Get Steam achievements with rarity",
+    description="Returns Steam achievements and global rarity percentages for a given Steam app ID."
+)
+def steam_achievements(app_id: str = Query(..., description="Steam app ID, such as 1245620 for Elden Ring")):
+    result = get_achievements_with_rarity(app_id)
 
     if result["status_code"] != 200:
         return error_response(
-            code = "Steam_Web_API_Error",
-            message = result.get("error", "Unknown Steam Player Error"),
-            status_code = result["status_code"]
-        )
-    else:
-        return success_response(
-            data = {
-                "player": result["player"]
-            }
-        )
-
-@router.get("/achievements/{game_name}")
-def steam_achievements(game_name: str):
-    result = get_achievements_with_rarity_by_name(game_name)
-
-    if result["status_code"] != 200:
-        return error_response(
-            code="Steam_Achievement_Error",
-            message=result.get("error", "Unknown Steam Achievement Error"),
+            code="STEAM_ACHIEVEMENT_ERROR",
+            message=result.get("error", "Unknown Steam achievement error"),
             status_code=result["status_code"]
         )
-    else:
-        return success_response(
-            data={
-                "game_name": result.get("resolved_game_name"),
-                "app_id": result.get("resolved_app_id"),
-                "steam_url": result.get("steam_url"),
-                "achievements": result.get("achievements", []),
-            }
-        )
+
+    return success_response(
+        data={
+            "game_name": result.get("game_name"),
+            "game_version": result.get("game_version"),
+            "achievements": result.get("achievements", []),
+        }
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI
-from app.api import steam, rawg
+from app.api import steam, rawg, combined
 from app.core.config import STEAM_API_KEY, RAWG_API_KEY
 
 app = FastAPI(title="Team 7 GameScope API")
 
 app.include_router(steam.router)
 app.include_router(rawg.router)
+app.include_router(combined.router)
 
 
 @app.get("/")

--- a/app/services/combined_service.py
+++ b/app/services/combined_service.py
@@ -1,0 +1,73 @@
+from app.services.rawg_service import search_for_steam_game_by_name
+from app.services.steam_service import get_achievements_with_rarity
+
+
+def get_full_report(game_name: str):
+    # RAWG lookup
+    rawg_result = search_for_steam_game_by_name(game_name)
+    if rawg_result.get("status_code") != 200:
+        return rawg_result
+
+    game_data = rawg_result.get("game", {})
+    app_id = game_data.get("steam_app_id")
+
+    if not app_id:
+        return {
+            "status_code": 404,
+            "error": "Steam app ID not found for this game",
+        }
+
+    # Steam achievements
+    achievements_result = get_achievements_with_rarity(app_id)
+    if achievements_result.get("status_code") != 200:
+        return achievements_result
+
+    achievements = achievements_result.get("achievements", [])
+
+    # Difficulty calculation
+    difficulty_score = calculate_difficulty_score(achievements)
+
+    # Final response
+    return {
+        "status_code": 200,
+        "game": {
+            "name": game_data.get("name"),
+            "release_date": game_data.get("release_date"),
+            "genres": game_data.get("genres"),
+            "tags": game_data.get("tags"),
+            "rating": game_data.get("rating"),
+            "description": game_data.get("description"),
+            "publishers": game_data.get("publishers"),
+
+            "steam_app_id": app_id,
+            "steam_url": game_data.get("steam_url"),
+
+            "achievement_count": len(achievements),
+            "difficulty_score": difficulty_score,
+            "achievements": achievements,
+        },
+    }
+
+
+def calculate_difficulty_score(achievements):
+    if not achievements:
+        return 0
+
+    total = 0
+    count = 0
+
+    for achievement in achievements:
+        percent = achievement.get("global_percentage")
+
+        if percent is None:
+            continue
+
+        try:
+            percent = float(percent)
+        except (TypeError, ValueError):
+            continue
+
+        total += (100 - percent)
+        count += 1
+    return round(total / count, 2) if count else 0
+

--- a/app/services/rawg_service.py
+++ b/app/services/rawg_service.py
@@ -5,7 +5,7 @@ from app.core.config import RAWG_API_KEY
 RAWG_BASE_URL = "https://api.rawg.io/api"
 
 
-def search_games(query: str):
+def search_for_steam_game_by_name(query: str):
     if not RAWG_API_KEY:
         return {
             "status_code": 500,
@@ -17,12 +17,12 @@ def search_games(query: str):
             "status_code": 400,
             "error": "Query parameter is required",
         }
-
+    # Search RAWG
     url = f"{RAWG_BASE_URL}/games"
     params = {
         "key": RAWG_API_KEY,
         "search": query.strip(),
-        "page_size": 5,
+        "page_size": 5,     #check a few results to make sure we find the Steam match
     }
 
     try:
@@ -58,35 +58,97 @@ def search_games(query: str):
             "status_code": 502,
             "error": "RAWG returned invalid JSON",
         }
+    
+    results = data.get("results", [])
+    if not results:
+        return {
+            "status_code": 404,
+            "error": "No game found"
+        }
 
-    simplified_results = []
-    for game in data.get("results", []):
-        simplified_results.append(
-            {
-                "id": game.get("id"),
-                "name": game.get("name"),
-                "slug": game.get("slug"),
-                "released": game.get("released"),
-                "rating": game.get("rating"),
-                "metacritic": game.get("metacritic"),
-                "platforms": [
-                    platform["platform"]["name"]
-                    for platform in game.get("platforms", [])
-                    if "platform" in platform and "name" in platform["platform"]
-                ],
-                "stores": [
-                    store["store"]["name"]
-                    for store in game.get("stores", [])
-                    if "store" in store and "name" in store["store"]
-                ],
-            }
-        )
+    # Find first game that exists on Steam
+    selected_game = None
+    steam_app_id = None
+    steam_url = None
 
+    for game in results:
+        rawg_id = game.get("id")
+
+        steam_info = find_steam_info_from_rawg_id(rawg_id)
+        if not steam_info:
+            continue
+
+        selected_game = game
+        steam_app_id = steam_info["app_id"]
+        steam_url = steam_info["steam_url"]
+        break
+    if not selected_game:
+        return {
+                "status_code": 404,
+                "error": "No Steam game found for this query"
+        }
+
+    # Assemble full game details
+    rawg_id = selected_game.get("id")
+    details_url = f"{RAWG_BASE_URL}/games/{rawg_id}"
+    params = {"key": RAWG_API_KEY}
+    try: 
+        response = requests.get(details_url, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.exceptions.RequestException:
+        return { 
+                "status_code": 500,
+                "error": "Failed to fetch game details",
+        } 
+    try: 
+        details = response.json()
+    except ValueError:
+        return {
+                "status_code": 502,
+                "error": "Invalid JSON from RAWG"
+        }
     return {
         "status_code": 200,
-        "count": data.get("count", 0),
-        "results": simplified_results,
+        "game": {
+            "name": details.get("name"),
+            "release_date": details.get("released"),
+            "rating": details.get("rating"),
+            "genres": [g["name"] for g in details.get("genres", [])],
+            "description": details.get("description_raw") or details.get("description"),
+            "publishers": [p["name"] for p in details.get("publishers", [])],
+            "tags": [t["name"] for t in details.get("tags", [])],
+            "steam_app_id": steam_app_id,
+            "steam_url": steam_url,
+        }, 
     }
+
+def find_steam_info_from_rawg_id(rawg_id: int):
+    stores_result = get_game_store_links(rawg_id)
+    if stores_result.get("status_code") != 200:
+        return None
+
+    for store_entry in stores_result.get("results", []):
+        store_name = (store_entry.get("store_name") or "").lower()
+        store_domain = (store_entry.get("store_domain") or "").lower()
+        store_url = store_entry.get("url")
+
+        is_steam = (
+            "steam" in store_name
+            or "steampowered.com" in store_domain
+            or ("steam" in (store_url or "").lower())
+        )
+
+        if not is_steam:
+            continue
+
+        app_id = extract_steam_app_id_from_url(store_url)
+        if app_id:
+            return {
+                "app_id": app_id,
+                "steam_url": store_url,
+            }
+
+    return None
 
 def get_game_store_links(rawg_game_id: int):
     if not RAWG_API_KEY:
@@ -145,9 +207,7 @@ def get_game_store_links(rawg_game_id: int):
         store = store_entry.get("store", {})
         simplified_results.append(
             {
-                "store_id": store.get("id"),
                 "store_name": store.get("name"),
-                "store_slug": store.get("slug"),
                 "store_domain": store.get("domain"),
                 "url": store_entry.get("url"),
             }
@@ -157,7 +217,6 @@ def get_game_store_links(rawg_game_id: int):
         "status_code": 200,
         "results": simplified_results,
     }
-
 
 def extract_steam_app_id_from_url(url: str):
     if not url:
@@ -172,60 +231,3 @@ def extract_steam_app_id_from_url(url: str):
         return match.group(1)
 
     return None
-
-
-def get_steam_app_id_from_game_name(game_name: str):
-    if not game_name or not game_name.strip():
-        return {
-            "status_code": 400,
-            "error": "Game name is required",
-        }
-
-    search_result = search_games(game_name)
-    if search_result.get("status_code") != 200:
-        return search_result
-
-    games = search_result.get("results", [])
-    if not games:
-        return {
-            "status_code": 404,
-            "error": "No RAWG game found for the given name",
-        }
-
-    for game in games:
-        rawg_game_id = game.get("id")
-        if rawg_game_id is None:
-            continue
-
-        stores_result = get_game_store_links(rawg_game_id)
-        if stores_result.get("status_code") != 200:
-            continue
-
-        for store_entry in stores_result.get("results", []):
-            store_name = (store_entry.get("store_name") or "").lower()
-            store_domain = (store_entry.get("store_domain") or "").lower()
-            store_url = store_entry.get("url")
-
-            is_steam = (
-                "steam" in store_name
-                or "steampowered.com" in store_domain
-                or ("steam" in (store_url or "").lower())
-            )
-
-            if not is_steam:
-                continue
-
-            app_id = extract_steam_app_id_from_url(store_url)
-            if app_id:
-                return {
-                    "status_code": 200,
-                    "app_id": app_id,
-                    "game_name": game.get("name"),
-                    "rawg_id": rawg_game_id,
-                    "steam_url": store_url,
-                }
-
-    return {
-        "status_code": 404,
-        "error": "No Steam app ID found for the given game name",
-    }

--- a/app/services/steam_service.py
+++ b/app/services/steam_service.py
@@ -1,89 +1,15 @@
 import requests
 from app.core.config import STEAM_API_KEY
-from app.services.rawg_service import get_steam_app_id_from_game_name
 
 STEAM_BASE_URL = "https://api.steampowered.com"
 
-
-def get_player_summary(steam_id: str):
-    if not STEAM_API_KEY:
-        return {
-            "status_code": 500,
-            "error": "STEAM_API_KEY is missing from .env",
-        }
-
-    if not steam_id or not steam_id.strip():
-        return {
-            "status_code": 400,
-            "error": "Steam ID is required",
-        }
-
-    cleaned_steam_id = steam_id.strip()
-
-    url = f"{STEAM_BASE_URL}/ISteamUser/GetPlayerSummaries/v2/"
-    params = {
-        "key": STEAM_API_KEY,
-        "steamids": cleaned_steam_id,
-    }
-
-    try:
-        response = requests.get(url, params=params, timeout=10)
-        response.raise_for_status()
-    except requests.exceptions.Timeout:
-        return {
-            "status_code": 504,
-            "error": "Request to Steam timed out",
-        }
-    except requests.exceptions.ConnectionError:
-        return {
-            "status_code": 503,
-            "error": "Could not connect to Steam",
-        }
-    except requests.exceptions.HTTPError:
-        return {
-            "status_code": response.status_code,
-            "error": "Steam returned an HTTP error",
-            "details": response.text,
-        }
-    except requests.exceptions.RequestException as e:
-        return {
-            "status_code": 500,
-            "error": "Unexpected Steam request error",
-            "details": str(e),
-        }
-
-    try:
-        data = response.json()
-    except ValueError:
-        return {
-            "status_code": 502,
-            "error": "Steam returned invalid JSON",
-        }
-
-    players = data.get("response", {}).get("players", [])
-    if not players:
-        return {
-            "status_code": 404,
-            "error": "No player found for the given Steam ID",
-            "player": None,
-        }
-
-    player = players[0]
-
-    simplified_player = {
-        "steamid": player.get("steamid"),
-        "personaname": player.get("personaname"),
-        "profileurl": player.get("profileurl"),
-        "avatarfull": player.get("avatarfull"),
-        "realname": player.get("realname"),
-        "loccountrycode": player.get("loccountrycode"),
-    }
-
-    return {
-        "status_code": 200,
-        "player": simplified_player,
-    }
-
+# Aquires and returns a list of a games achievements based on its app_id
+# Includes achievement's:
+# 1. name
+# 2. display_name
+# 3. description
+# 4. hidden flag
+# 4. icon url
 def get_game_achievements(app_id: str):
     if not STEAM_API_KEY:
         return {
@@ -166,7 +92,10 @@ def get_game_achievements(app_id: str):
         "achievements": simplified_achievements,
     }
 
-
+# Aquires and returns a list of global achievement percentages based on app_id
+# Includes achievement's:
+# 1. name
+# 2. percentage
 def get_global_achievement_percentages(app_id: str):
     if not app_id or not str(app_id).strip():
         return {
@@ -236,7 +165,15 @@ def get_global_achievement_percentages(app_id: str):
         "achievement_percentages": simplified_percentages,
     }
 
-
+# Combines the output of get_global_achievement_percentages and get_game_achievements
+# Ensures that the correct percentages are mapped to the correct achievements
+# Includes achievement's:
+# 1. name
+# 2. display_name
+# 3. description
+# 4. hidden flag
+# 5. icon url
+# 6. global_percentage
 def get_achievements_with_rarity(app_id: str):
     achievements_result = get_game_achievements(app_id)
     if achievements_result.get("status_code") != 200:
@@ -273,20 +210,3 @@ def get_achievements_with_rarity(app_id: str):
         "game_version": achievements_result.get("game_version"),
         "achievements": combined_achievements,
     }
-
-def get_achievements_with_rarity_by_name(game_name: str):
-    app_id_result = get_steam_app_id_from_game_name(game_name)
-    if app_id_result.get("status_code") != 200:
-        return app_id_result
-
-    app_id = app_id_result.get("app_id")
-    achievements_result = get_achievements_with_rarity(app_id)
-
-    if achievements_result.get("status_code") != 200:
-        return achievements_result
-
-    achievements_result["resolved_app_id"] = app_id
-    achievements_result["resolved_game_name"] = app_id_result.get("game_name")
-    achievements_result["steam_url"] = app_id_result.get("steam_url")
-
-    return achievements_result


### PR DESCRIPTION
## Changes
- Added `combined_service` to aggregate data from RAWG and Steam
- Implemented difficulty score calculation using achievement rarity
- Created `/report` endpoint to return a full game intelligence report
- Refactored RAWG service to return Steam-compatible game data
- Simplified Steam service to focus on achievements and global percentages
- Removed unused service methods and duplicate logic
- Updated routing to reflect new structure

## New Endpoint
```
GET /report?game_name=<name>
```

### Returns:
- Game name  
- Release date  
- Genre  
- Rating  
- Description  
- Publishers  
- Tags  
- Difficulty score (based on achievement rarity)

## Difficulty Score
The difficulty score is calculated as:

```
average(100 - global_achievement_percentage)
```

This represents the average rarity of achievements:
- Lower completion % → higher difficulty contribution  
- Higher completion % → lower difficulty contribution  

## Notes
- This work was originally planned as multiple issues (service refactor, difficulty scoring, combined endpoint)
- Due to interdependencies between services, changes were consolidated into a single refactor to maintain consistency and reduce duplication
- This PR closes Issues:
#17 
#18 
#19 

## Testing
- Verified `/report` endpoint in Swagger UI
- Tested with sample queries (e.g., "elden ring")
- Confirmed valid aggregation of RAWG + Steam data
- Confirmed difficulty score calculation works with real achievement data
