### PR TITLE
Added game's cover art URL into the full report's output

### DIFF
--- a/backend/src/team7cs3321gamescope/services/combined_service.py
+++ b/backend/src/team7cs3321gamescope/services/combined_service.py
@@ -41,6 +41,7 @@ def get_full_report(game_name: str):
 
             "steam_app_id": app_id,
             "steam_url": game_data.get("steam_url"),
+            "cover_art": game_data.get("cover_art"),
 
             "achievement_count": len(achievements),
             "difficulty_score": difficulty_score,

--- a/backend/src/team7cs3321gamescope/services/rawg_service.py
+++ b/backend/src/team7cs3321gamescope/services/rawg_service.py
@@ -119,6 +119,7 @@ def search_for_steam_game_by_name(query: str):
             "tags": [t["name"] for t in details.get("tags", [])],
             "steam_app_id": steam_app_id,
             "steam_url": steam_url,
+            "cover_art": details.get("background_image"),
         }, 
     }
 


### PR DESCRIPTION
## Summary
Adds a game-level image field to the combined report response so the frontend can display an icon/cover image for each game.

## Changes
- Added a game image field sourced from RAWG game details
- Passed the image field through the combined report response
- Kept existing Steam achievement icon behavior unchanged
- Preserved the rest of the combined report structure and data flow

## Why
The frontend already has achievement icons available, but it did not have a game-level image to use for cards, search results, or report displays. This change provides that missing display asset without requiring extra frontend-side lookups.

## Verification
- Ran the backend locally
- Queried the combined report endpoint through Swagger (`/docs`)
- Confirmed the response now includes the new game-level image field
- Verified existing fields like achievements, difficulty score, Steam app ID, and other metadata still return as expected

## Result
- Frontend can now use a game-level image directly from the combined report response
- No changes to existing achievement icon behavior
- Minimal API expansion with no major architectural changes